### PR TITLE
remove time from witness data feed

### DIFF
--- a/src/nodes/GenesisNode/child/index.js
+++ b/src/nodes/GenesisNode/child/index.js
@@ -101,7 +101,7 @@ class GenesisNodeChild extends AbstractChild {
 		})
 
 		const datafeed = {
-			time: new Date().toString(),
+			// time: new Date().toString(),
 			timestamp: Date.now(),
 		}
 		this.composer.composeDataFeedJoint(this.address, datafeed, this.headlessWallet.signer, callbacks)

--- a/src/nodes/ObyteWitness/child/index.js
+++ b/src/nodes/ObyteWitness/child/index.js
@@ -128,7 +128,7 @@ class ObyteWitnessChild extends AbstractChild {
 
 		this.headlessWallet.readSingleAddress(address => {
 			const datafeed = {
-				time: new Date().toString(),
+				// time: new Date().toString(),
 				timestamp: Date.now(),
 			}
 			this.composer.composeDataFeedJoint(address, datafeed, this.headlessWallet.signer, callbacks)


### PR DESCRIPTION
the time string might be too long in some timezones, in particular Eastern European Standard Time, and exceed constants.MAX_DATA_FEED_VALUE_LENGTH. It's not used anyway.